### PR TITLE
Fix building against not-currently-running kernels

### DIFF
--- a/dkms_e1000e.conf
+++ b/dkms_e1000e.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="e1000e"
 PACKAGE_VERSION="3.4.0.2"
 CLEAN="cd src & make clean"
-MAKE[0]="cd src && make install"
+MAKE[0]="cd src && KVERSION=$kernelver BUILD_KERNEL=$kernelver make"
 BUILT_MODULE_NAME[0]="e1000e"
 BUILT_MODULE_LOCATION[0]="src"
 DEST_MODULE_LOCATION[0]="/updates"

--- a/dkms_ixgbe.conf
+++ b/dkms_ixgbe.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="ixgbe"
 PACKAGE_VERSION="5.3.6"
 CLEAN="cd src & make clean"
-MAKE[0]="cd src && make install"
+MAKE[0]="cd src && KVERSION=$kernelver BUILD_KERNEL=$kernelver make"
 BUILT_MODULE_NAME[0]="ixgbe"
 BUILT_MODULE_LOCATION[0]="src"
 DEST_MODULE_LOCATION[0]="/updates"


### PR DESCRIPTION
It appears we were always building against the current kernel only,
resulting in errors when booting the new kernel and trying to load
modules:

```
e1000e: disagrees about version of symbol module_layout
```