### PR TITLE
Add mpt3sas driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /build
 
 # Versions to download and build
 ENV e1000e_version "3.4.0.2"
-ENV ixgbe_version "5.3.6"
+ENV ixgbe_version "5.3.7"
 
 # Download folders will probably have to be updated when versions are incremented
 RUN wget https://downloadmirror.intel.com/15817/eng/e1000e-${e1000e_version}.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,14 +33,42 @@ WORKDIR /build
 # Versions to download and build
 ENV e1000e_version "3.4.0.2"
 ENV ixgbe_version "5.3.7"
+ENV mpt3sas_version "22.00.00.00"
 
-# Download folders will probably have to be updated when versions are incremented
+# Package containing many things including the actual mpt3sas source
+ENV mpt3sas_zip_version "RHEL6-7_SLES11-12_P15"
+
 RUN wget https://downloadmirror.intel.com/15817/eng/e1000e-${e1000e_version}.tar.gz
 RUN wget https://downloadmirror.intel.com/14687/eng/ixgbe-${ixgbe_version}.tar.gz
+ENV mpt3sas Linux_Driver_${mpt3sas_zip_version}
+RUN wget https://www.supermicro.com/wftp/driver/SAS/LSI/3224/Driver/Linux/${mpt3sas}.zip
 
-RUN tar xf e1000e-${e1000e_version}.tar.gz -C /usr/src/
-RUN tar xf ixgbe-${ixgbe_version}.tar.gz -C /usr/src/
-RUN rm *.tar.gz
+# Extract mpt3sas
+# The actual source package is a few levels deep
+RUN unzip ${mpt3sas}.zip \
+  && rm *.zip
+
+RUN mkdir /tmp/sas
+RUN tar xf ${mpt3sas}/mpt3sas_rhel5_rel/mpt3sas-release.tar.gz -C /tmp/sas/ \
+  && rm -rf ${mpt3sas}
+
+RUN tar xf /tmp/sas/mpt3sas-${mpt3sas_version}-src.tar.gz -C /usr/src/ \
+  && mv /usr/src/mpt3sas /usr/src/mpt3sas-${mpt3sas_version} \
+  && rm -rf /tmp/sas/
+
+# Extract NIC drivers
+RUN tar xf e1000e-${e1000e_version}.tar.gz -C /usr/src/ \
+  && tar xf ixgbe-${ixgbe_version}.tar.gz -C /usr/src/ \
+  && rm *.tar.gz
+
+# Build mpt3sas
+ENV mpt3sas_conf /usr/src/mpt3sas-${mpt3sas_version}/dkms.conf
+COPY dkms.conf.mpt3sas ${mpt3sas_conf}
+RUN sed -i "s/__PACKAGE__/mpt3sas/g" ${mpt3sas_conf}
+RUN sed -i "s/__VERSION__/${mpt3sas_version}/g" ${mpt3sas_conf}
+
+RUN dkms add -m mpt3sas -v ${mpt3sas_version}
+RUN dkms mkdeb --source-only -m mpt3sas -v ${mpt3sas_version}
 
 # Build e1000e
 ENV e1000e_conf /usr/src/e1000e-${e1000e_version}/dkms.conf

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Build DKMS packages for ixgbe and e100e drivers
+# Build DKMS packages for ixgbe, e100e, and mpt3sas drivers
 
 Use Docker to help build debianized DKMS drivers
 
@@ -7,10 +7,10 @@ Use Docker to help build debianized DKMS drivers
 ## General
 
 ```sh
-# build for precise by default
+# build for Trusty by default
 make build
-# build for trusty
-make build-trusty
+# build for precise
+make build-precise
 ```
 
 All packages built in the docker container will appear in the `output` directory.

--- a/dkms.conf.mpt3sas
+++ b/dkms.conf.mpt3sas
@@ -1,0 +1,8 @@
+PACKAGE_NAME="__PACKAGE__"
+PACKAGE_VERSION="__VERSION__"
+CLEAN="./clean.sh"
+MAKE="make -C $kernel_source_dir M=/usr/src/__PACKAGE__-__VERSION__"
+BUILT_MODULE_NAME="__PACKAGE__"
+DEST_MODULE_LOCATION=/kernel/drivers/scsi/mpt3sas/
+AUTOINSTALL="yes"
+REMAKE_INITRD=yes

--- a/dkms.conf.mpt3sas
+++ b/dkms.conf.mpt3sas
@@ -3,6 +3,7 @@ PACKAGE_VERSION="__VERSION__"
 CLEAN="./clean.sh"
 MAKE="make -C $kernel_source_dir M=/usr/src/__PACKAGE__-__VERSION__"
 BUILT_MODULE_NAME="__PACKAGE__"
+BUILT_MODULE_LOCATION="../source"
 DEST_MODULE_LOCATION=/kernel/drivers/scsi/mpt3sas/
 AUTOINSTALL="yes"
 REMAKE_INITRD=yes


### PR DESCRIPTION
- Add mpt3sas driver
- Drive-by: Update ixgbe version (the old version is no longer available)
- Drive-by: Update `README.md` to reflect new default distribution

This is currently buggy.  Although building with `dpkg-reconfigure mpt3sas-dkms` seems to work great, on initial install it claims failure:

```
Selecting previously unselected package mpt3sas-dkms.
(Reading database ... 298149 files and directories currently installed.)
Preparing to unpack mpt3sas-dkms_22.00.00.00_all.deb ...
Unpacking mpt3sas-dkms (22.00.00.00) ...
Setting up mpt3sas-dkms (22.00.00.00) ...
Loading new mpt3sas-22.00.00.00 DKMS files...
First Installation: checking all kernels...
Building only for 3.13.0-153-generic
Building for architecture x86_64
Building initial module for 3.13.0-153-generic
ERROR (dkms apport): kernel package linux-headers-3.13.0-153-generic is not supported
Error!  Build of mpt3sas.ko failed for: 3.13.0-153-generic (x86_64)
Consult the make.log in the build directory
/var/lib/dkms/mpt3sas/22.00.00.00/build/ for more information.
```

... This in spite of `make.log` not seeming to show any errors:

```
DKMS make.log for mpt3sas-22.00.00.00 for kernel 3.13.0-153-generic (x86_64)
Fri Aug 17 12:35:32 EDT 2018
make: Entering directory `/usr/src/linux-headers-3.13.0-153-generic'
  LD      /usr/src/mpt3sas-22.00.00.00/built-in.o
  CC [M]  /usr/src/mpt3sas-22.00.00.00/mpt3sas_base.o
  CC [M]  /usr/src/mpt3sas-22.00.00.00/mpt3sas_config.o
  CC [M]  /usr/src/mpt3sas-22.00.00.00/mpt3sas_warpdrive.o
  CC [M]  /usr/src/mpt3sas-22.00.00.00/mpt3sas_scsih.o
  CC [M]  /usr/src/mpt3sas-22.00.00.00/mpt3sas_transport.o
  CC [M]  /usr/src/mpt3sas-22.00.00.00/mpt3sas_ctl.o
  CC [M]  /usr/src/mpt3sas-22.00.00.00/mpt3sas_trigger_diag.o
  LD [M]  /usr/src/mpt3sas-22.00.00.00/mpt3sas.o
  Building modules, stage 2.
  MODPOST 1 modules
  CC      /usr/src/mpt3sas-22.00.00.00/mpt3sas.mod.o
  LD [M]  /usr/src/mpt3sas-22.00.00.00/mpt3sas.ko
make: Leaving directory `/usr/src/linux-headers-3.13.0-153-generic'
```